### PR TITLE
fix(State): Return state as a function

### DIFF
--- a/src/module/state_builder.ts
+++ b/src/module/state_builder.ts
@@ -1,7 +1,7 @@
 import ModuleBuildConfig from "./build_config";
 
 function build(buildConfig: ModuleBuildConfig) {
-  return buildConfig.state();
+  return buildConfig.state;
 }
 
 export default build;


### PR DESCRIPTION
If state is a function, it is already called in this library, when in fact the function should be called in Vuex itself.

I couldn't create a test to test this behaviour, but Typescript currently states that buildState returns a type of `<any>`, whereas the [`build_config.ts`](https://github.com/eunjae-lee/vuex-dry/blob/3663ea5afb93cdf7ffc554cb6b8c5b0b2dc58f1d/src/module/build_config.ts#L15) states that state should return a `Function`. This PR fixes that behaviour.

This change should be implemented because of the thorough explanation found here: https://stackoverflow.com/questions/49557177/vuex-state-returned-as-function-or-object-literal

I'm happy to hear your thoughts.